### PR TITLE
upgrade typed-ast

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyparsing==2.4.0
 pytest==4.6.1
 pytest-mock==1.10.4
 six==1.12.0
-typed-ast==1.5.0
+typed-ast==1.4.1
 wcwidth==0.1.7
 wrapt==1.11.1
 zipp==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyparsing==2.4.0
 pytest==4.6.1
 pytest-mock==1.10.4
 six==1.12.0
-typed-ast==1.3.5
+typed-ast==1.5.0
 wcwidth==0.1.7
 wrapt==1.11.1
 zipp==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,6 @@ pylint==2.3.1
 pyparsing==2.4.0
 pytest==4.6.1
 six==1.12.0
-typed-ast==1.3.5
 wcwidth==0.1.7
 wrapt==1.11.1
 zipp==0.5.1


### PR DESCRIPTION
### :pushpin: References
* **Issue:** [`iss2`](https://github.com/IBM/clai/tree/iss2 )

### :tophat: What is the goal?

[Upgrade](https://github.com/IBM/clai/blob/iss2/requirements.txt#L20) to fix installation error for old `typed-ast` package.

### :memo: How is it being implemented?

`typed-ast 1.3.5` --> `typed-ast 1.4.1`
