### PR TITLE
added default value of data

### DIFF
--- a/clai/server/plugins/nlc2cmd/wa_skills/tarbot.py
+++ b/clai/server/plugins/nlc2cmd/wa_skills/tarbot.py
@@ -15,8 +15,9 @@ wa_endpoint = 'http://nlc2cmd-chipper-impala.us-east.mybluemix.net/tarbot'
 
 def wa_skill_processor_tarbot(msg):
 
-    # Confidence remains at 0 unless an intent has been detected
-    confidence = 0.0 
+    # Confidence remains at 0 and data is None unless an intent has been detected
+    confidence = 0.0
+    data = None
 
     if msg.startswith('tar'):
         return None, 0.0


### PR DESCRIPTION
### :pushpin: References
* **Issue:** fixes #13 

### :tophat: What is the goal?

To fix  UnboundLocalError: local variable 'data' referenced before assignment in nlc2cmd/wa_skills/tarbot.py

### :memo: How is it being implemented?
By fixing if-else condition. Note that the value of data is taken from `$ tar --help`. If none of the default conditions are executed this will be the default value. Note that I am not able to reproduce this bug now before writing this patch maybe due to some strange query written by me which I cannot remember. 
