### PR TITLE
enabled question based invocation for howdoi skill

### DIFF
--- a/clai/server/plugins/howdoi/howdoi.py
+++ b/clai/server/plugins/howdoi/howdoi.py
@@ -10,6 +10,7 @@ from clai.tools.colorize_console import Colorize
 from clai.server.plugins.howdoi.data import Datastore
 from clai.server.agent import Agent
 from clai.server.command_message import State, Action, NOOP_COMMAND
+from clai.server.plugins.howdoi.question_detection import QuestionDetection
 
 from clai.server.logger import current_logger as logger
 
@@ -18,6 +19,7 @@ class HowDoIAgent(Agent):
     def __init__(self):
         super(HowDoIAgent, self).__init__()
         self.store = Datastore()
+        self.questionIdentifier = QuestionDetection()
 
     def compute_simple_token_similarity(self, src_sequence, tgt_sequence):
         src_tokens = set([x.lower().strip() for x in src_sequence.split()])
@@ -29,6 +31,15 @@ class HowDoIAgent(Agent):
 
         logger.info("================== In HowDoI Bot:get_next_action ========================")
         logger.info("User Command: {}".format(state.command))
+
+        # Invoke "howdoi" plugin only when a question is asked
+        is_question = self.questionIdentifier.is_question(state.command)
+
+        if not is_question:
+            return Action(
+                suggested_command=state.command,
+                confidence=0.0
+            )
 
         # Query data store to find closest matching forum
         forum = self.store.search(state.command, service='stack_exchange', size=1)

--- a/clai/server/plugins/howdoi/question_detection.py
+++ b/clai/server/plugins/howdoi/question_detection.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020 IBM. All Rights Reserved.
+#
+# See LICENSE.txt file in the root directory
+# of this source tree for licensing information.
+#
+
+import spacy
+
+
+class QuestionDetection(object):
+
+    def __init__(self):
+        self.nlp = spacy.load('en_core_web_sm')
+        self.WH_TAGS = ['WDT', 'WP', 'WP$', 'WRB']  # WH word tags. These signify the presence of an interrogative word
+
+    def is_question(self, text):
+        """
+        A function to check if text is phrased as a question.
+
+        Algorithm:
+            1. Test if the text ends with "?". If yes, then it's a question.
+            2. Test if the text contains any "WH" word tags (indicative of WH type of question)
+
+        Args:
+            text (str): a text to be tested
+
+        Returns:
+            (bool): True if the text is a question.
+        """
+
+        if text.endswith('?'):
+            return True
+
+        doc = self.nlp(text)
+        for token in doc:
+            if token.tag_ in self.WH_TAGS:
+                return True
+
+        return False

--- a/clai/server/plugins/howdoi/requirements.txt
+++ b/clai/server/plugins/howdoi/requirements.txt
@@ -1,1 +1,3 @@
 requests
+spacy
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz#egg=en_core_web_sm

--- a/test/test_clai_plugins_howdoi.py
+++ b/test/test_clai_plugins_howdoi.py
@@ -18,6 +18,32 @@ class SearchAgentTest(unittest.TestCase):
         cls.agent = _agent
 
     @unittest.skip("Only for local testing")
+    def test_get_next_action_pwd_without_question(self):
+        self.agent.init_agent()
+
+        state = State(user_name='tester', command_id='0', command="pwd")
+        action = self.agent.get_next_action(state=state)
+        print("Input: {}".format(state.command))
+        print("===========================")
+        print("Response: {}".format(action.suggested_command))
+        print("===========================")
+        print("Explanation: {}".format(action.description))
+        self.assertEqual('pwd', action.suggested_command)
+
+    @unittest.skip("Only for local testing")
+    def test_get_next_action_pwd_with_question(self):
+        self.agent.init_agent()
+
+        state = State(user_name='tester', command_id='0', command="What is pwd?")
+        action = self.agent.get_next_action(state=state)
+        print("Input: {}".format(state.command))
+        print("===========================")
+        print("Response: {}".format(action.suggested_command))
+        print("===========================")
+        print("Explanation: {}".format(action.description))
+        self.assertEqual('man pwd', action.suggested_command)
+
+    @unittest.skip("Only for local testing")
     def test_get_next_action_sudo(self):
         self.agent.init_agent()
 

--- a/test/test_clai_plugins_howdoi.py
+++ b/test/test_clai_plugins_howdoi.py
@@ -11,6 +11,7 @@ from clai.server.command_message import State
 from clai.server.plugins.howdoi.howdoi import HowDoIAgent
 
 
+@unittest.skip("Only for local testing")
 class SearchAgentTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### :pushpin: References
* **Issue:** `howdoi` skill invokes for built-in bash commands. 

### :tophat: What is the goal?

`howdoi` skill invokes for built-in bash commands causing unwanted behavior. In order to curtain invocation of `howdoi` skill, additional requirements were added to invocation pattern. 

`howdoi` skill can be only invoked for "WH" type questions now on.  For example, 
1. pwd -> will result into execution of `pwd` bash command 
2. what is pwd? -> will result into response from `howdoi` skill (when active) as `man pwd`

### :memo: How is it being implemented?

All incoming requests (commands) to `howdoi` skill now are tested to ensure that they are "WH"-type question. If they are not, then the command is returned as it is without activating `howdoi` assist logic. 

### :tv: Screenshot or gif showing the result.
New `howdoi` plugin in action:
![howdoi_invocation_change](https://user-images.githubusercontent.com/3219735/76435278-304b4800-638d-11ea-9de5-fbad41b654db.gif)

Local integration test results:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3219735/76435312-3b9e7380-638d-11ea-9959-869246bbbb91.png">


### :boom: How can it be tested?

Install CLAI, activate `howdoi` plugin
- [ ] **Use case 1:** Type `pwd` and the response should show current working directory 
- [ ] **Use case 2:** Type `what is pwd?` and the response should show `man pwd`
- [ ] **Use case 3:** Earlier usecase are still valid, type `clai "howdoi" find out disk usage per user?" and it should return "man df"
