### PR TITLE
importlib-metadata version fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ websockets
 astroid==2.2.5
 atomicwrites==1.3.0
 attrs==19.1.0
-importlib-metadata==0.17
+importlib-metadata==0.20
 isort==4.3.20
 lazy-object-proxy==1.4.1
 mccabe==0.6.1
@@ -24,7 +24,6 @@ zipp==0.5.1
 astroid==2.2.5
 atomicwrites==1.3.0
 attrs==19.1.0
-importlib-metadata==0.17
 isort==4.3.20
 lazy-object-proxy==1.4.1
 mccabe==0.6.1


### PR DESCRIPTION
### :pushpin: References
* **Issue:** [`iss27`](https://github.com/IBM/clai/issues/27)

### :tophat: What is the goal?

Fix version error from `importlib-metadata` package

```
ERROR: catalogue 0.0.8 has requirement importlib-metadata>=0.20; python_version < "3.8", but you'll have importlib-metadata 0.17 which is incompatible.
```

### :memo: How is it being implemented?

+ removed duplicate `importlib-metadata` entry in requirements
+ upgraded to `importlib-metadata==0.20`

Refer to changes to [requirements.txt](https://github.com/IBM/clai/blob/iss27/requirements.txt)