### PR TITLE
Highlighted user and pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ $ ./BuildDockerImage.sh
 ```
 
 **Fedora and Ubuntu**
+### Control flags:
+```
+ flags (BuildDockerImage.sh) 
+  - ${DOCKER_BUILD_FLAGS-"--no-cache"}, for kernel version above 4.4.0-173-generic (xenial xerus/ Ubuntu 16.04 LTS).
+  - ${DOCKER_BUILD_FLAGS-""}, for kernel version below 4.4.0-173-generic, per say 4.4.0-75-generic (Trusty Tahr/ Ubuntu 14.04 LTS).
+```
+
 ```
 $ sudo ./BuildDockerImage.sh
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ ./BuildDockerImage.sh
 **Fedora and Ubuntu**
 ### Control flags:
 ```
- flags (BuildDockerImage.sh) 
+ flags (BuildDockerImage.sh) While using default docker version.
   - ${DOCKER_BUILD_FLAGS-"--no-cache"}, for kernel version above 4.4.0-173-generic (xenial xerus/ Ubuntu 16.04 LTS).
   - ${DOCKER_BUILD_FLAGS-""}, for kernel version below 4.4.0-173-generic, per say 4.4.0-75-generic (Trusty Tahr/ Ubuntu 14.04 LTS).
 ```

--- a/RunDockerImage.sh
+++ b/RunDockerImage.sh
@@ -33,5 +33,5 @@ docker run --privileged							  	 \
            -v ${HostBaseDir}:${ContainerBaseDir}      \
            --name CLAIBotPlayground					  \
 	   claiplayground
-FGGREEN= echo "\033[32m"
-echo "${FGGREEN}User for ssh is root and the default pass Bashpass"
+
+echo -e "\e[32mUser for ssh is root and the default pass Bashpass\e[0m"

--- a/RunDockerImage.sh
+++ b/RunDockerImage.sh
@@ -34,4 +34,6 @@ docker run --privileged							  	 \
            --name CLAIBotPlayground					  \
 	   claiplayground
 
-echo -e "\e[32mUser for ssh is root and the default pass Bashpass\e[0m"
+COL_GREEN="\x1b[32;01m"
+COL_RESET="\x1b[39;49;00m"
+echo -e $COL_GREEN"User for ssh is root and the default pass Bashpass"$COL_RESET

--- a/RunDockerImage.sh
+++ b/RunDockerImage.sh
@@ -33,5 +33,5 @@ docker run --privileged							  	 \
            -v ${HostBaseDir}:${ContainerBaseDir}      \
            --name CLAIBotPlayground					  \
 	   claiplayground
-
-echo 'User for ssh is root and the default pass Bashpass'
+FGGREEN= echo "\033[32m"
+echo "${FGGREEN}User for ssh is root and the default pass Bashpass"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** fixes _your issue goes here_
* **Related pull-requests:** _list of related pull-requests (comma-separated): #9, #26  

### :tophat: What is the goal?
a) The goal here is better visibility of username and password of the server deployed using docker. b) Documentation of control flags for build docker image in different versions of Ubuntu.

### :memo: How is it being implemented?
a) -e option of echo enables the parsing of the escape sequence. Here “\e[32m” sequence changes the colour of text to green while the “\e[0m” sequence removes all the colour and formatting at the end(Updated)
b) keeping the value of flags empty in docker build script completes the process without error for default docker build in kernel version 4.4.0-75-generic (Trusty Tahr/ Ubuntu 14.04 LTS). While the rest remains the usual for ubuntu 16.04 and above. We have added descriptive explanations as control flags in Readme under the container build section. 

### :tv: Screenshot or gif showing the result.
![Screenshot](https://user-images.githubusercontent.com/9550258/77235746-cb62cf80-6b8e-11ea-9aa7-75b3f89f21f4.png)

_Introduce here a gif or picture about the work_

### :boom: How can it be tested?
It can be tested by running the command sudo ./RunDockerImage.sh for the same.
